### PR TITLE
GS-18: Add ColorBreakdown component that is used in the profile page

### DIFF
--- a/components/ColorBreakdown/index.js
+++ b/components/ColorBreakdown/index.js
@@ -1,0 +1,12 @@
+import styles from "./styles.module.css";
+
+const ColorBreakdown = () => {
+  return (
+    <div className={styles.container}>
+      <text className={styles.breakdownHeader}>Total Color Breakdown</text>
+      <div className={styles.progressBar}>Progress Bar</div>
+    </div>
+  );
+};
+
+export default ColorBreakdown;

--- a/components/ColorBreakdown/styles.module.css
+++ b/components/ColorBreakdown/styles.module.css
@@ -1,0 +1,18 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  margin: 0 34px;
+  gap: 16px;
+}
+
+.breakdownHeader {
+  text-align: left;
+  font-size: larger;
+}
+
+.progressBar {
+  border: 1px solid rgb(168, 168, 168);
+  border-radius: 3px;
+  height: 64px;
+  background-color: rgb(211, 211, 211);
+}

--- a/components/Statistics/index.js
+++ b/components/Statistics/index.js
@@ -7,7 +7,7 @@ const Statistics = () => {
     <div className={styles.container}>
       <text className={styles.statsHeading}>Statistics</text>
       <div className={styles.statsRow}>
-        <StatsCard title="DayStreak" />
+        <StatsCard title="Day Streak" />
         <StatsCard title="Carrots" />
       </div>
       <div className={styles.statsRow}>

--- a/components/StatsCard/index.js
+++ b/components/StatsCard/index.js
@@ -3,7 +3,7 @@ import styles from "./styles.module.css";
 const StatsCard = ({ title }) => {
   return (
     <div className={styles.container}>
-      <text>{title}</text>
+      <text className={styles.title}>{title}</text>
     </div>
   );
 };

--- a/components/StatsCard/index.js
+++ b/components/StatsCard/index.js
@@ -3,7 +3,7 @@ import styles from "./styles.module.css";
 const StatsCard = ({ title }) => {
   return (
     <div className={styles.container}>
-      <text className={styles.title}>{title}</text>
+      <text>{title}</text>
     </div>
   );
 };

--- a/components/StatsCard/styles.module.css
+++ b/components/StatsCard/styles.module.css
@@ -7,6 +7,6 @@
   text-align: left;
 }
 
-.title {
+.container text {
   font-size: small;
 }

--- a/components/StatsCard/styles.module.css
+++ b/components/StatsCard/styles.module.css
@@ -1,7 +1,12 @@
 .container {
   border: 1px solid rgb(177, 177, 177);
   width: 45%;
-  height: 75px;
+  height: 64px;
   background-color: rgb(210, 210, 210);
   border-radius: 3px;
+  text-align: left;
+}
+
+.title {
+  font-size: small;
 }

--- a/pages/profile/index.js
+++ b/pages/profile/index.js
@@ -1,6 +1,7 @@
 import Heading1 from "../../components/Heading1";
 import UserInfo from "../../components/UserInfo";
 import Statistics from "../../components/Statistics";
+import ColorBreakdown from "../../components/ColorBreakdown";
 
 import styles from "./styles.module.css";
 
@@ -11,6 +12,7 @@ const ProfilePage = () => {
       <Heading1>Profile</Heading1>
       <UserInfo />
       <Statistics />
+      <ColorBreakdown />
     </div>
   );
 };


### PR DESCRIPTION
Created a ColorBreakdown component which is then used in profile page. Pic below:
<img width="376" alt="Screen Shot 2022-08-11 at 4 21 24 PM" src="https://user-images.githubusercontent.com/100656411/184258471-c6499a92-b368-48e3-9ef5-7fa9929b0126.png">