### PR TITLE
GS-36: Add BottomTabs layout

### DIFF
--- a/components/BottomTabs/index.js
+++ b/components/BottomTabs/index.js
@@ -1,0 +1,13 @@
+import styles from "./styles.module.css";
+
+const BottomTabs = () => {
+  return (
+    <div className={styles.container}>
+      <div>Today</div>
+      <div>Add</div>
+      <div>Profile</div>
+    </div>
+  );
+};
+
+export default BottomTabs;

--- a/components/BottomTabs/styles.module.css
+++ b/components/BottomTabs/styles.module.css
@@ -1,0 +1,13 @@
+.container {
+  display: flex;
+  justify-content: space-between;
+  position: fixed;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  border-top: 1px solid rgb(204, 204, 204);
+}
+
+.container > div {
+  margin: 20px 34px;
+}

--- a/components/BottomTabs/styles.module.css
+++ b/components/BottomTabs/styles.module.css
@@ -2,9 +2,7 @@
   display: flex;
   justify-content: space-between;
   position: fixed;
-  bottom: 0;
-  right: 0;
-  left: 0;
+  inset: auto 0 0;
   border-top: 1px solid rgb(204, 204, 204);
 }
 

--- a/pages/eat/index.js
+++ b/pages/eat/index.js
@@ -1,9 +1,11 @@
-import Heading1 from "../../components/Heading1/index";
+import Heading1 from "../../components/Heading1";
+import BottomTabs from "../../components/BottomTabs";
 
 const Eat = () => {
   return (
     <div>
       <Heading1>What are you eating</Heading1>
+      <BottomTabs />
     </div>
   );
 };

--- a/pages/profile/index.js
+++ b/pages/profile/index.js
@@ -2,6 +2,7 @@ import Heading1 from "../../components/Heading1";
 import UserInfo from "../../components/UserInfo";
 import Statistics from "../../components/Statistics";
 import ColorBreakdown from "../../components/ColorBreakdown";
+import BottomTabs from "../../components/BottomTabs";
 
 import styles from "./styles.module.css";
 
@@ -13,6 +14,7 @@ const ProfilePage = () => {
       <UserInfo />
       <Statistics />
       <ColorBreakdown />
+      <BottomTabs />
     </div>
   );
 };

--- a/pages/profile/styles.module.css
+++ b/pages/profile/styles.module.css
@@ -1,5 +1,4 @@
 .container {
-  height: 100vh;
   text-align: center;
 }
 

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -1,5 +1,6 @@
 import SettingsInputs from "../../components/SettingsInputs";
 import Heading1 from "../../components/Heading1";
+import BottomTabs from "../../components/BottomTabs";
 
 import styles from "./styles.module.css";
 
@@ -8,6 +9,7 @@ const SettingsPage = () => {
     <div className={styles.container}>
       <Heading1>Settings</Heading1>
       <SettingsInputs />
+      <BottomTabs />
     </div>
   );
 };

--- a/pages/today/index.js
+++ b/pages/today/index.js
@@ -1,6 +1,7 @@
 import Heading1 from "../../components/Heading1";
 import TodayInfo from "../../components/TodayInfo";
 import WeeklyConsumption from "../../components/WeeklyConsumption";
+import BottomTabs from "../../components/BottomTabs";
 
 import styles from "./styles.module.css";
 
@@ -10,6 +11,7 @@ const Today = () => {
       <Heading1>Today</Heading1>
       <TodayInfo />
       <WeeklyConsumption />
+      <BottomTabs />
     </div>
   );
 };

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,6 +1,5 @@
 html,
 body {
-  height: 100%;
   padding: 0;
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,


### PR DESCRIPTION
Created a BottomTabs component and put it in all the pages that use the BottomTabs navigator. Pics below:
<img width="189" alt="Screen Shot 2022-08-12 at 12 32 07 PM" src="https://user-images.githubusercontent.com/100656411/184430449-6851207e-816d-4279-a365-a8ede0f0c873.png">   <img width="188" alt="Screen Shot 2022-08-12 at 12 31 45 PM" src="https://user-images.githubusercontent.com/100656411/184430471-67f47d31-c9c7-4fbf-bb19-f63d4a3012c3.png">
<img width="188" alt="Screen Shot 2022-08-12 at 12 32 32 PM" src="https://user-images.githubusercontent.com/100656411/184430482-bf2b5cf4-f5da-419b-ab44-3172fc7d2a54.png">   <img width="190" alt="Screen Shot 2022-08-12 at 12 32 48 PM" src="https://user-images.githubusercontent.com/100656411/184430489-db7dcb15-0fe1-4bba-ba2c-fec22ec9dc95.png">


