### PR TITLE
GS-106: color hifi updates to today page

### DIFF
--- a/components/TodayInfo/index.js
+++ b/components/TodayInfo/index.js
@@ -9,12 +9,12 @@ const TodayInfo = () => {
       </div>
       <div className={styles.listContainer}>
         <ul className={styles.foodList}>
-          <li>Kale</li>
-          <li>Lettuce</li>
-          <li>Apple</li>
-          <li>Blueberry</li>
-          <li>Plum</li>
-          <li>Banana</li>
+          <li className={styles.green}>Kale</li>
+          <li className={styles.tan}>Onion</li>
+          <li className={styles.red}>Apple</li>
+          <li className={styles.blue}>Blueberry</li>
+          <li className={styles.orange}>Orange</li>
+          <li className={styles.yellow}>Banana</li>
         </ul>
       </div>
     </div>

--- a/components/TodayInfo/styles.module.css
+++ b/components/TodayInfo/styles.module.css
@@ -23,6 +23,7 @@
   border-radius: 3px;
   padding: 16px;
   height: 144px;
+  background-color: var(--card-background-purple);
 }
 
 .foodList {
@@ -30,4 +31,28 @@
   margin: 0;
   padding: 0;
   font-size: small;
+}
+
+.red {
+  color: var(--list-red);
+}
+
+.orange {
+  color: var(--list-orange);
+}
+
+.yellow {
+  color: var(--list-yellow);
+}
+
+.green {
+  color: var(--list-green);
+}
+
+.blue {
+  color: var(--list-blue);
+}
+
+.tan {
+  color: var(--list-tan);
 }

--- a/components/TodayInfo/styles.module.css
+++ b/components/TodayInfo/styles.module.css
@@ -24,6 +24,7 @@
   padding: 16px;
   height: 144px;
   background-color: var(--card-background-purple);
+  box-shadow: 1px 1px 2px grey;
 }
 
 .foodList {

--- a/components/WeeklyConsumption/styles.module.css
+++ b/components/WeeklyConsumption/styles.module.css
@@ -5,6 +5,7 @@
 .container p {
   text-align: left;
   font-size: larger;
+  color: var(--purple-dark);
 }
 
 .barChart {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -26,7 +26,7 @@ a {
   --filter-green: #6aab9c;
   --filter-blue: #4b37a8;
   --filter-tan: #f2edcf;
-  --list-red: -#f94d4d;
+  --list-red: #f94d4d;
   --list-orange: #fd8f52;
   --list-yellow: #ffbb1c;
   --list-green: #479d45;


### PR DESCRIPTION
Mostly color update on today page. As seen in picture still having a problem with page container divs filling up the view height.
<img width="281" alt="Screen Shot 2022-08-17 at 2 25 47 PM" src="https://user-images.githubusercontent.com/100656411/185246188-60936697-b8fd-4f12-9bde-f88f1689fffd.png">

