### PR TITLE
GS-130: Add about page with nav and image credits

### DIFF
--- a/components/SettingsButtons/index.js
+++ b/components/SettingsButtons/index.js
@@ -1,4 +1,7 @@
+import Link from "next/link";
+
 import LargeLinkedButton from "../LargeLinkedButton";
+import SmallLinkedButton from "../SmallLinkedButton";
 
 import styles from "./styles.module.css";
 
@@ -16,6 +19,7 @@ const SettingsButtons = () => {
       <LargeLinkedButton href="/settings/delete-account">
         Delete Account
       </LargeLinkedButton>
+      <LargeLinkedButton href="/settings/about">About Glow</LargeLinkedButton>
     </div>
   );
 };

--- a/components/SettingsButtons/index.js
+++ b/components/SettingsButtons/index.js
@@ -1,7 +1,6 @@
 import Link from "next/link";
 
 import LargeLinkedButton from "../LargeLinkedButton";
-import SmallLinkedButton from "../SmallLinkedButton";
 
 import styles from "./styles.module.css";
 

--- a/pages/settings/about/index.js
+++ b/pages/settings/about/index.js
@@ -1,0 +1,26 @@
+import Heading1 from "../../../components/Heading1/index";
+
+import styles from "./styles.module.css";
+
+const AboutUs = () => {
+  return (
+    <div className={styles.container}>
+      <Heading1>About Glow</Heading1>
+      <p>
+        Glow is a food tracker app inspired by the Rainbow Diet and science
+        linking nutrition to the colors of natural foods.
+      </p>
+      <p>
+        This app is intended for all ages. It is not indended to treat,
+        diagnose, prevent, or cure diseases.
+      </p>
+      <p>
+        Icons are made by
+        <a href="https://www.flaticon.com/authors/freepik"> Freepik</a> from
+        <a href="https://www.flaticon.com/"> www.flaticon.com</a>.
+      </p>
+    </div>
+  );
+};
+
+export default AboutUs;

--- a/pages/settings/about/index.js
+++ b/pages/settings/about/index.js
@@ -1,4 +1,7 @@
+import Link from "next/link";
+
 import Heading1 from "../../../components/Heading1/index";
+import BottomTabs from "../../../components/BottomTabs/index";
 
 import styles from "./styles.module.css";
 
@@ -6,6 +9,9 @@ const AboutUs = () => {
   return (
     <div className={styles.container}>
       <Heading1>About Glow</Heading1>
+      <Link href="/settings">
+        <a className={styles.doneLink}>Done</a>
+      </Link>
       <p>
         Glow is a food tracker app inspired by the Rainbow Diet and science
         linking nutrition to the colors of natural foods.
@@ -19,6 +25,7 @@ const AboutUs = () => {
         <a href="https://www.flaticon.com/authors/freepik"> Freepik</a> from
         <a href="https://www.flaticon.com/"> www.flaticon.com</a>.
       </p>
+      <BottomTabs />
     </div>
   );
 };

--- a/pages/settings/about/styles.module.css
+++ b/pages/settings/about/styles.module.css
@@ -4,7 +4,7 @@
   flex-direction: column;
   justify-content: flex-start;
   text-align: center;
-  margin: 0px 34px 0px;
+  margin: 0 34px;
   padding-top: 17px;
 }
 
@@ -12,9 +12,13 @@
   color: var(--purple-dark);
   font-size: medium;
   text-align: left;
-  font-size: medium;
 }
 
 .container a {
   color: black;
+}
+
+.doneLink {
+  position: absolute;
+  inset: 15px 15px auto auto;
 }

--- a/pages/settings/about/styles.module.css
+++ b/pages/settings/about/styles.module.css
@@ -1,0 +1,20 @@
+.container {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  text-align: center;
+  margin: 0px 34px 0px;
+  padding-top: 17px;
+}
+
+.container p {
+  color: var(--purple-dark);
+  font-size: medium;
+  text-align: left;
+  font-size: medium;
+}
+
+.container a {
+  color: black;
+}


### PR DESCRIPTION
Done link navigates back to Settings. Credit hyperlinks navigate to FlatIcon author page and FlatIcon homepage.
<img width="343" alt="Screen Shot 2022-08-19 at 12 02 55 PM" src="https://user-images.githubusercontent.com/93552075/185689220-76a107e7-045b-4185-bf59-699a240aeca1.png">
<img width="342" alt="Screen Shot 2022-08-19 at 12 02 44 PM" src="https://user-images.githubusercontent.com/93552075/185689228-29cc419e-18b4-4f4f-a441-c33bc16cd73a.png">

